### PR TITLE
fix Spring for single node graph

### DIFF
--- a/src/spring.jl
+++ b/src/spring.jl
@@ -106,6 +106,7 @@ function Base.iterate(iter::LayoutIterator{<:Spring}, state)
     # Now apply them, but limit to temperature
     for i in 1:N
         force_mag = norm(force[i])
+        iszero(force_mag) && continue
         scale = min(force_mag, temp) ./ force_mag
         locs[i] += force[i] .* scale
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,6 +153,13 @@ jagmesh_adj = jagmesh()
             @test positions ==
                   spring(adj_matrix; C=2.0, iterations=100, initialtemp=2.0, Ptype=Float32, dim=3)
         end
+
+        @testset "test single node graph" begin
+            g = SimpleGraph(1)
+            pos = Spring()(g)
+            @test length(pos) == 1
+            @test !isnan(pos[1])
+        end
     end
 
     @testset "Testing Spectral Algorithm" begin


### PR DESCRIPTION
Returned `NaN` before. See <https://github.com/JuliaPlots/GraphMakie.jl/issues/28>

Note: This will still do all the iterations which is kinda pointless. But i think a some point we might want to stop the iteration after some tolerance is reached anyway (similar to SFDP).