### PR TITLE
fix stress layout

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -111,16 +111,22 @@ Stress
 ```
 ### Example
 ```@example layouts
-g = complete_graph(10)
+g = SimpleGraph(936)
+for l in eachline(joinpath(@__DIR__,"..","..","test","jagmesh1.mtx"))
+    s = split(l, " ")
+    src, dst = parse(Int, s[1]), parse(Int, s[2])
+    src != dst && add_edge!(g, src, dst)
+end
+
 layout = Stress(Ptype=Float32)
-f, ax, p = graphplot(g, layout=layout)
+f, ax, p = graphplot(g; layout=layout, node_size=3, edge_width=1)
 hidedecorations!(ax); hidespines!(ax); ax.aspect = DataAspect(); f #hide
 ```
 
 ### Iterator Example
 ```@example layouts
 iterator = LayoutIterator(layout, g)
-record(f, "stress_animation.mp4", iterator; framerate = 10) do pos
+record(f, "stress_animation.mp4", iterator; framerate = 7) do pos
     p[:node_pos][] = pos
     autolimits!(ax)
 end

--- a/src/NetworkLayout.jl
+++ b/src/NetworkLayout.jl
@@ -108,6 +108,28 @@ function assertsquare(M::AbstractMatrix)
 end
 
 """
+    make_symmetric!(M::AbstractMatrix)
+
+Pairwise check [i,j] and [j,i]. If one is zero, make symmetric.
+If both are different and nonzero throw ArgumentError.
+"""
+function make_symmetric!(A::AbstractMatrix)
+    indsm, indsn = axes(A)
+    for i in first(indsn):last(indsn), j in (i):last(indsn)
+        if A[i,j] == A[j,i]   # allready symmetric
+            continue
+        elseif iszero(A[i,j])
+            A[i,j] = A[j,i]
+        elseif iszero(A[j,i])
+            A[j,i] = A[i,j]
+        else
+            throw(ArgumentError("Matrix can't be symmetrized!"))
+        end
+    end
+    return A
+end
+
+"""
     @addcall
 
 Annotate subtypes of `AbstractLayout` to create a lowercase function call for them.

--- a/src/stress.jl
+++ b/src/stress.jl
@@ -72,9 +72,15 @@ The main equation to solve is (8) of:
     seed::UInt
 end
 
-function Stress(; dim=2, Ptype=Float64, iterations=:auto, abstols=(√(eps(Float64))),
-                reltols=(√(eps(Float64))), abstolx=(√(eps(Float64))), weights=Array{Float64}(undef, 0, 0),
-                initialpos=Point{dim,Ptype}[], seed=1)
+function Stress(; dim=2,
+                Ptype=Float64,
+                iterations=:auto,
+                abstols=0.0,
+                reltols=10e-6,
+                abstolx=10e-6,
+                weights=Array{Float64}(undef, 0, 0),
+                initialpos=Point{dim,Ptype}[],
+                seed=1)
     if !isempty(initialpos)
         initialpos = Point.(initialpos)
         Ptype = eltype(eltype(initialpos))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,23 @@ jagmesh_adj = jagmesh()
             @test typeof(positions) == Vector{Point3f}
             @test positions == stress(adj_matrix; iterations=10, dim=3, Ptype=Float32)
         end
+
+        @testset "test pairwise_distance" begin
+            using NetworkLayout: make_symmetric!, pairwise_distance
+            δ = [0 1 0 0 1;
+                 1 0 0 1 0;
+                 0 0 0 1 1;
+                 0 1 1 0 0;
+                 1 0 1 0 0]
+            d = pairwise_distance(δ)
+
+            @test d == make_symmetric!([0 1 2 2 1;
+                                        0 0 2 1 2;
+                                        0 0 0 1 1;
+                                        0 0 0 0 2;
+                                        0 0 0 0 0])
+
+        end
     end
 
     @testset "Testing Spring Algorithm" begin
@@ -298,5 +315,33 @@ jagmesh_adj = jagmesh()
         @test_throws ArgumentError spring(M1)
         @test_throws ArgumentError squaregrid(M1)
         @test_throws ArgumentError stress(M1)
+    end
+
+    @testset "make_symmetric" begin
+        using LinearAlgebra: issymmetric
+        using NetworkLayout: make_symmetric!
+
+        M = [1 0; 0 1]
+        make_symmetric!(M)
+        @test issymmetric(M)
+
+        M = [0 1; 0 0]
+        make_symmetric!(M)
+        @test issymmetric(M)
+
+        M = [0 0; 1 0]
+        make_symmetric!(M)
+        @test issymmetric(M)
+
+        M = [0 -1; 1 0]
+        @test_throws ArgumentError make_symmetric!(M)
+
+        M = [1  0  2;
+             6  2  4;
+             2  0  3]
+        make_symmetric!(M)
+        @test M == [1  6  2;
+                    6  2  4;
+                    2  4  3]
     end
 end


### PR DESCRIPTION
This PR fixes the stress layout according to the cited paper (see #39). It mainly introduces the `pairwise_distances` function which calculates the minimum distance between ALL nodes (not only the connected) and uses those as the "optimal distance" for drawing. It is slower now (calculating all distances is O(n^3) 😢 )... but at least it produces nice layouts now^^

Technicially this is breaking but if @SimonDanisch agrees I'd still publish this as a patch release... i doubt someone is using the layout as is.

@mroavi can you check if this works as expected with your example?

https://user-images.githubusercontent.com/35867212/133418478-81682edc-e60f-4e75-88d6-7ba51ebe8038.mp4

