### PR TITLE
Update to Documenter 1 and update CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,14 +3,42 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "3"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main(; subdirs=["", "docs"])
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,3 +5,10 @@ GraphMakie = "1ecd5474-83a3-4783-bb4f-06765db800d2"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 NetworkLayout = "46757867-2c16-5918-afeb-47bfcb05e46a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[compat]
+CairoMakie = "0.10"
+Documenter = "1"
+GraphMakie = "0.5"
+Graphs = "1.9"
+NetworkLayout = "0.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,8 @@ makedocs(; modules=[NetworkLayout],
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true",
                                 canonical="https://juliagraphs.org/NetworkLayout.jl", assets=String[]),
          pages=["Home" => "index.md",
-                "Interface" => "interface.md"])
+                "Interface" => "interface.md"],
+         warnonly=[:missing_docs])
 
 # if gh_pages branch gets to big, check out
 # https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,24 +7,12 @@ using CairoMakie
 DocMeta.setdocmeta!(NetworkLayout, :DocTestSetup, :(using NetworkLayout); recursive=true)
 
 makedocs(; modules=[NetworkLayout],
-         repo="https://github.com/JuliaGraphs/NetworkLayout.jl/blob/{commit}{path}#{line}",
+         repo=Remotes.GitHub("JuliaGraphs", "NetworkLayout.jl"),
          sitename="NetworkLayout.jl",
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", "false") == "true",
                                 canonical="https://juliagraphs.org/NetworkLayout.jl", assets=String[]),
          pages=["Home" => "index.md",
-                "Interface" => "interface.md"],
-         strict=[:autodocs_block,
-                 :cross_references,
-                 :docs_block,
-                 :doctest,
-                 :eval_block,
-                 :example_block,
-                 :footnote,
-                 :linkcheck,
-                 :meta_block,
-                 #:missing_docs,
-                 :parse_error,
-                 :setup_block])
+                "Interface" => "interface.md"])
 
 # if gh_pages branch gets to big, check out
 # https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#gh-pages-Branch


### PR DESCRIPTION
The PR updates the `makedocs` call in `docs/make.jl` to Documenter 1 and removes the keyword arguments that were removed in Documenter 1. To avoid such issues with breaking changes in the future, I also added compat entries to `docs/Project.toml`, as suggested by the Documenter docs, and enabled CompatHelper for the docs environment. I used the opportunity to update the CompatHelper action with the template in the CompatHelper repo.

Should fix the docs build failure in #58.