### PR TITLE
store RNG instead of seed in iterative layouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,15 +13,16 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1'
+          - 'lts' # long-term support release
+          - '1'   # latest stable 1.x release
+          - 'pre' # latest stable prerelease
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -38,15 +39,15 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NetworkLayout"
 uuid = "46757867-2c16-5918-afeb-47bfcb05e46a"
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/Project.toml
+++ b/Project.toml
@@ -9,15 +9,19 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[weakdeps]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+
+[extensions]
+NetworkLayoutGraphsExt = "Graphs"
+
 [compat]
 GeometryBasics = "0.4"
 Graphs = "1"
 Requires = "1"
+StableRNGs = "1.0.2"
 StaticArrays = "1"
 julia = "1.6"
-
-[extensions]
-NetworkLayoutGraphsExt = "Graphs"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
@@ -25,10 +29,8 @@ GeometryTypes = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Graphs", "Test", "DelimitedFiles", "GeometryTypes", "SparseArrays"]
-
-[weakdeps]
-Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+test = ["Graphs", "Test", "DelimitedFiles", "GeometryTypes", "SparseArrays", "StableRNGs"]

--- a/src/NetworkLayout.jl
+++ b/src/NetworkLayout.jl
@@ -8,6 +8,11 @@ using StaticArrays
 export LayoutIterator
 
 """
+Default RNG for layouts.
+"""
+const DEFAULT_RNG = Ref{DataType}(MersenneTwister)
+
+"""
     AbstractLayout{Dim,Ptype}
 
 Abstract supertype for all layouts. Each layout `Layout <: AbstractLayout` needs to

--- a/src/sfdp.jl
+++ b/src/sfdp.jl
@@ -108,10 +108,10 @@ function Base.iterate(iter::LayoutIterator{<:SFDP}, state)
             end
         end
         if any(isnan, force)
-            # if two points are at the exact same location
-            # use random force in any direction
-            rng = copy(algo.rng)
-            force += randn(rng, Ftype)
+            # if two points are at the exact same location use random force in any direction
+            # copy rng from alg struct to not advance the "initial" rng state
+            # otherwise algo(g)==algo(g) might be broken
+            force += randn(copy(algo.rng), Ftype)
         end
         mask = (!).(pin[i]) # where pin=true mask will multiply with 0
         locs[i] = locs[i] .+ (step .* (force ./ norm(force))) .* mask

--- a/src/spring.jl
+++ b/src/spring.jl
@@ -114,8 +114,9 @@ function Base.iterate(iter::LayoutIterator{<:Spring}, state)
             else
                 # if two points are at the exact same location
                 # use random force in any direction
-                rng = copy(algo.rng)
-                force_vec += randn(rng, Ftype)
+                # copy rng from alg struct to not advance the "initial" rng state
+                # otherwise algo(g)==algo(g) might be broken
+                force_vec += randn(copy(algo.rng), Ftype)
             end
 
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,9 @@ using GeometryBasics
 using DelimitedFiles: readdlm
 using SparseArrays: sparse
 using StaticArrays
+using StableRNGs
 using Test
+using Random
 
 function jagmesh()
     jagmesh_path = joinpath(dirname(@__FILE__), "jagmesh1.mtx")
@@ -63,6 +65,14 @@ jagmesh_adj = jagmesh()
             positions = @time SFDP(; dim=3, Ptype=Float32, tol=0.1, K=1)(adj_matrix)
             @test typeof(positions) == Vector{Point3f}
             @test positions == sfdp(adj_matrix; dim=3, Ptype=Float32, tol=0.1, K=1)
+
+            NetworkLayout.DEFAULT_RNG[] = StableRNG
+            l = SFDP()
+            @test l.rng isa StableRNG
+            li = LayoutIterator(l, g)
+            p1, p2 = iterate(li)[1], iterate(li)[1]
+            @test p1 == p2
+            NetworkLayout.DEFAULT_RNG[] = MersenneTwister
         end
     end
 
@@ -112,6 +122,14 @@ jagmesh_adj = jagmesh()
             positions = @time Stress(; iterations=10, dim=3, Ptype=Float32)(adj_matrix)
             @test typeof(positions) == Vector{Point3f}
             @test positions == stress(adj_matrix; iterations=10, dim=3, Ptype=Float32)
+
+            NetworkLayout.DEFAULT_RNG[] = StableRNG
+            l = Stress()
+            @test l.rng isa StableRNG
+            li = LayoutIterator(l, g)
+            p1, p2 = iterate(li)[1], iterate(li)[1]
+            @test p1 == p2
+            NetworkLayout.DEFAULT_RNG[] = MersenneTwister
         end
 
         @testset "test pairwise_distance" begin
@@ -170,6 +188,14 @@ jagmesh_adj = jagmesh()
             @test typeof(positions) == Vector{Point3f}
             @test positions ==
                   spring(adj_matrix; C=2.0, iterations=100, initialtemp=2.0, Ptype=Float32, dim=3)
+
+            NetworkLayout.DEFAULT_RNG[] = StableRNG
+            l = Spring()
+            @test l.rng isa StableRNG
+            li = LayoutIterator(l, g)
+            p1, p2 = iterate(li)[1], iterate(li)[1]
+            @test p1 == p2
+            NetworkLayout.DEFAULT_RNG[] = MersenneTwister
         end
 
         @testset "test single node graph" begin


### PR DESCRIPTION
allows to customize `DEFAULT_RNG[]` on a global basis to use stable RNGs in testing of GraphMakie (ref https://github.com/MakieOrg/GraphMakie.jl/pull/190)