### PR TITLE
Bump julia-actions/cache to v3, remove cache-save workaround

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,23 +29,13 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - name: Load Julia packages from cache
-        id: julia-cache
-        uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
           file: lcov.info
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -57,9 +47,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - name: Load Julia packages from cache
-        id: julia-cache
-        uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:
@@ -71,11 +59,3 @@ jobs:
             using NetworkLayout
             DocMeta.setdocmeta!(NetworkLayout, :DocTestSetup, :(using NetworkLayout); recursive=true)
             doctest(NetworkLayout)'
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}


### PR DESCRIPTION
## Summary

- Bumps \`julia-actions/cache\` to v3 where needed
- Removes the manual \`actions/cache/save\` fallback steps that were needed in v2 to save the cache on failure/cancellation — v3 handles this natively via a post-step (\`save-always: true\` by default)
- Drops the now-orphaned \`id: julia-cache\` and step name from the cache steps

See the [v3 release notes](https://github.com/julia-actions/cache/pull/169) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)