### PR TITLE
jetls fixes

### DIFF
--- a/src/NetworkLayout.jl
+++ b/src/NetworkLayout.jl
@@ -150,7 +150,7 @@ function _sanitize_initialpos_pin(dim, Ptype, initialpos, pin)
 
     _pin = Dict{Int,SVector{dim,Bool}}()
     for (k, v) in pairs(pin)
-        if v == nothing
+        if isnothing(v)
             continue
         elseif v isa Bool
             _pin[k] = SVector{dim,Bool}(v for i in 1:dim)
@@ -214,7 +214,8 @@ macro addcall(expr::Expr)
     @assert typedef isa Expr &&
             typedef.head === :<: &&
             typedef.args[2] isa Expr && # supertype
-            typedef.args[2].args[1] ∈ [:AbstractLayout, :IterativeLayout] "Macro must be used on subtype of AbstractLayout"
+            (typedef.args[2].args[1] === :AbstractLayout ||
+             typedef.args[2].args[1] === :IterativeLayout) "Macro must be used on subtype of AbstractLayout"
 
     if typedef.args[1] isa Symbol # no type parameters
         name = typedef.args[1]

--- a/src/align.jl
+++ b/src/align.jl
@@ -9,7 +9,7 @@ Also automatically centers the layout origin to its center of mass (average node
 
 Only supports two-dimensional inner layouts.
 """
-@addcall struct Align{Ptype, L <: AbstractLayout{2, Ptype}} <: AbstractLayout{2, Ptype}
+struct Align{Ptype, L <: AbstractLayout{2, Ptype}} <: AbstractLayout{2, Ptype}
     inner_layout :: L
     angle :: Ptype
     function Align(inner_layout::L, angle::Real) where {L <: AbstractLayout{2, Ptype}} where Ptype

--- a/src/buchheim.jl
+++ b/src/buchheim.jl
@@ -56,7 +56,7 @@ end
 function adj_mat_to_list(M::AbstractMatrix)
     N = size(M, 1)
     list = Vector{Vector{Int}}(undef, N)
-    for i in 1:N
+    for i in eachindex(list)
         list[i] = findall(!iszero, view(M, i, :))
     end
     return list
@@ -83,7 +83,7 @@ end
 
 function parent(v, t::Tree)
     tree = t.nodes
-    for i in 1:length(tree)
+    for i in eachindex(tree)
         if v ∈ tree[i]
             return i
         end
@@ -97,7 +97,7 @@ function first_walk(v, t::Tree)
     tree = t.nodes
     nodesize = t.nodesize
     p = parent(v, t)
-    if p != nothing
+    if !isnothing(p)
         index = findall(x -> (x == v), tree[p])[1]
     else
         index = 1
@@ -134,7 +134,7 @@ function apportion(v::T, defaultAncestor::T, t::Tree) where {T}
     thread = t.thread
     p = parent(v, t)
     nodesize = t.nodesize
-    if p != nothing
+    if !isnothing(p)
         index = findall(x -> (x == v), tree[p])[1]
     else
         index = 1

--- a/src/sfdp.jl
+++ b/src/sfdp.jl
@@ -148,7 +148,7 @@ end
 
 function dist_tolerance(locs, locs0, K, tol)
     # check whether the layout is optimal
-    for i in 1:size(locs, 1)
+    for i in eachindex(locs, locs0)
         if norm(locs[i] .- locs0[i]) >= K * tol
             return false
         end

--- a/src/spectral.jl
+++ b/src/spectral.jl
@@ -26,7 +26,7 @@ Spectral(; dim=3, Ptype=Float64, nodeweights=Float64[]) = Spectral{dim,Ptype,elt
 
 function make_symmetric(adj_matrix::AbstractMatrix)
     adj_matrix = copy(adj_matrix)
-    for i in 1:size(adj_matrix, 1), j in (i + 1):size(adj_matrix, 2)
+    for i in axes(adj_matrix, 1), j in (i + 1):lastindex(adj_matrix, 2)
         adj_matrix[i, j] = adj_matrix[j, i] = adj_matrix[i, j] + adj_matrix[j, i]
     end
     return adj_matrix

--- a/src/squaregrid.jl
+++ b/src/squaregrid.jl
@@ -40,10 +40,11 @@ function layout(algo::SquareGrid{Ptype}, adj_matrix::AbstractMatrix) where {Ptyp
     end
 
     positions = Vector{Point2{Ptype}}(undef, N)
+    skip = Set(algo.skip)
 
     n = 1
     for j in 1:typemax(Int), i in 1:cols
-        if (j, i) ∉ algo.skip
+        if (j, i) ∉ skip
             positions[n] = Point2{Ptype}((i - 1) * algo.dx, (j - 1) * algo.dy)
             n += 1
             n > N && break

--- a/src/stress.jl
+++ b/src/stress.jl
@@ -125,7 +125,7 @@ function Base.iterate(iter::LayoutIterator{<:Stress{Dim,Ptype,IT,FT}}) where {Di
     distances = pairwise_distance(δ, FT)
 
     # check for unconnected commponents and set pairwise distances
-    if any(isequal(typemax(FT)), distances)
+    if (any(isinf, distances))::Bool
         maxd = maximum(filter(isfinite, distances))
         laplacian = weightedlaplacian(δ)
         Ncomponents = size(nullspace(laplacian),2)


### PR DESCRIPTION
Various fixes for issues found by jetls, such as 
- using `isnothing` over `== nothing`.
- explicit `===` over `∈`, since `∈` can return `missing`, whereas `===` on `Symbol`s always returns a `Bool`.
- `@addcall` generated `align(g; kwargs...) = layout(Align(; kwargs...), g)`, but `Align` has no all-keyword constructor.
- `SquareGrid` skip-list check now uses a `Set` instead of `Vector`, avoiding the same `missing`-prone `∈`.
- `Stress` uses `any(isinf, distances)` instead of `any(isequal(typemax(FT)), distances)`.
- replaced `for i in 1:length(x)`/`1:size(x, 1)` loops with `eachindex`/`axes`.